### PR TITLE
Add support for reading voltage and movement counter

### DIFF
--- a/qml/pages/GetDataPage.qml
+++ b/qml/pages/GetDataPage.qml
@@ -1,6 +1,6 @@
 /*
     Skruuvi - Reader for Ruuvi sensors
-    Copyright (C) 2023  Miika Malin
+    Copyright (C) 2023-2024  Miika Malin
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -262,6 +262,10 @@ Page {
                 loadingScreen.text = "Connected, fetching data"
             } else if (data[0] === "data_received_amount") {
                 loadingScreen.text = "Connected, received " + data[1] + " readings"
+            } else if (data[0] === "extra_data") {
+                // Update voltage and movement counter
+                db.setVoltage(selectedDevice.deviceAddress, data[1])
+                db.setMovement(selectedDevice.deviceAddress, data[2])
             } else if (data[0] === "failed") {
                 loadingScreen.running = false;
                 failureOverlay.visible = true;

--- a/qml/pages/SelectDevicePage.qml
+++ b/qml/pages/SelectDevicePage.qml
@@ -1,6 +1,6 @@
 /*
     Skruuvi - Reader for Ruuvi sensors
-    Copyright (C) 2023  Miika Malin
+    Copyright (C) 2023-2024  Miika Malin
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -112,6 +112,8 @@ Page {
                     deviceModel.append({
                         deviceName: device.deviceName,
                         deviceAddress: device.deviceAddress,
+                        deviceVoltage: device.deviceVoltage,
+                        deviceMovement: device.deviceMovement,
                         showBluetoothIcon: false
                     });
                 }
@@ -164,6 +166,7 @@ Page {
                     }
 
                     Image {
+                        id: btIcon
                         source: "image://theme/icon-s-bluetooth"
                         width: Theme.iconSizeSmall
                         height: Theme.iconSizeSmall
@@ -172,6 +175,32 @@ Page {
                             right: parent.right
                             rightMargin: Theme.paddingMedium
                             verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    Image {
+                        id: batteryIcon
+                        source: "image://theme/icon-m-battery"
+                        width: Theme.iconSizeSmall
+                        height: Theme.iconSizeSmall
+                        anchors {
+                            left: topLabel.right
+                            leftMargin: Theme.paddingMedium
+                            verticalCenter: parent.verticalCenter
+                            verticalCenterOffset: -topLabel.height / 2
+                        }
+                    }
+
+                    Image {
+                        id: movementIcon
+                        source: "image://theme/icon-s-sync"
+                        width: Theme.iconSizeSmall
+                        height: Theme.iconSizeSmall
+                        anchors {
+                            left: voltageLabel.right
+                            leftMargin: Theme.paddingMedium
+                            verticalCenter: parent.verticalCenter
+                            verticalCenterOffset: -topLabel.height / 2
                         }
                     }
 
@@ -185,6 +214,25 @@ Page {
                     }
 
                     Label {
+                        id: voltageLabel
+                        text: model.deviceVoltage + " V"
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.verticalCenterOffset: -topLabel.height / 2
+                        anchors.left: batteryIcon.right
+                        anchors.leftMargin: Theme.paddingSmall
+                    }
+
+                    Label {
+                        id: movementLabel
+                        text: model.deviceMovement + " Moves"
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.verticalCenterOffset: -topLabel.height / 2
+                        anchors.left: movementIcon.right
+                        anchors.leftMargin: Theme.paddingSmall
+                    }
+
+                    Label {
+                        id: bottomLabel
                         anchors.top: topLabel.bottom
                         text: model.deviceAddress
                         font.pixelSize: Theme.fontSizeSmall
@@ -302,6 +350,37 @@ Page {
     }
 
     Connections {
+        target: db
+        onVoltageUpdated: {
+            // Find the device with the matching mac address in the model
+            var deviceFound = false;
+            for (var i = 0; i < deviceModel.count; i++) {
+                var device = deviceModel.get(i);
+                if (device.deviceAddress === mac) {
+                    deviceFound = true;
+                    // Update the voltage for the matched device
+                    deviceModel.setProperty(i, "deviceVoltage", voltage.toString());
+                    console.log("Voltage updated for " + mac);
+                    break;
+                }
+            }
+        }
+        onMovementUpdated: {
+            var deviceFound = false;
+            for (var i = 0; i < deviceModel.count; i++) {
+                var device = deviceModel.get(i);
+                if (device.deviceAddress === mac) {
+                    deviceFound = true;
+                    // Update the movement for the matched device
+                    deviceModel.setProperty(i, "deviceMovement", movement.toString());
+                    console.log("Movement updated for " + mac);
+                    break;
+                }
+            }
+        }
+    }
+
+    Connections {
         target: ld
         onDeviceFound: {
             // Check if a device with the same address already exists in the model
@@ -320,6 +399,8 @@ Page {
                 deviceModel.append({
                     deviceName: deviceName,
                     deviceAddress: deviceAddress,
+                    deviceVoltage: "NA",
+                    deviceMovement: "NA",
                     showBluetoothIcon: true
                 });
             }

--- a/qml/pages/ruuvi_read.py
+++ b/qml/pages/ruuvi_read.py
@@ -10,7 +10,7 @@ https://docs.ruuvi.com/communication/bluetooth-connection
 
 License:
     Skruuvi - Reader for Ruuvi sensors
-    Copyright (C) 2023  Miika Malin
+    Copyright (C) 2023-2024  Miika Malin
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -43,8 +43,9 @@ ALL_SENSORS = 0x3A
 # Charasteristic UUIDS
 UART_RX_CHAR_UUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
 UART_TX_CHAR_UUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
-# Magic value for log read
-LOG_READ = 0x11
+# Magic values
+LOG_READ = 0x11  # Log read command
+ADV_DATA = 0x05  # Header information for advertisement data
 
 
 class RuuviTagReader:
@@ -97,6 +98,18 @@ class RuuviTagReader:
                                             "data_received_amount",
                                             self.data_received_amount
                                         ])
+            elif data[0] == ADV_DATA:
+                if len(data) != 18:
+                    print("Wrong advertisement data size", flush=True)
+                else:
+                    print("Advertisement data received", flush=True)
+                    dat = struct.unpack('>BhHHhhhHBH', data)
+                    voltage = ((dat[7] >> 5) + 1600) / 1000
+                    movement_counter = dat[8]
+                    pyotherside.send([
+                                      "extra_data",
+                                      round(voltage, 2), movement_counter
+                                    ])
 
     async def read_log_data(self):
         print(f"Searching for Ruuvi {self.device_address}", flush=True)

--- a/src/database.h
+++ b/src/database.h
@@ -1,6 +1,6 @@
 /*
     Skruuvi - Reader for Ruuvi sensors
-    Copyright (C) 2023  Miika Malin
+    Copyright (C) 2023-2024  Miika Malin
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -37,12 +37,17 @@ public:
     Q_INVOKABLE void renameDevice(const QString deviceAddress, const QString newDeviceName);
     Q_INVOKABLE void removeDevice(const QString deviceAddress);
     Q_INVOKABLE QString exportCSV(const QString deviceAddress, const QString deviceName, int startTime, int endTime);
+    Q_INVOKABLE void setVoltage(const QString &mac, double voltage);
+    Q_INVOKABLE void setMovement(const QString &mac, int movement);
 
 private:
     QSqlDatabase db;
+    void checkAndAddColumn(const QString &tableName, const QString &columnName, const QString &columnType);
 
 signals:
     void inputFinished();
+    void voltageUpdated(const QString &mac, double voltage);
+    void movementUpdated(const QString &mac, int movement);
 };
 
 #endif // DATABASE_H


### PR DESCRIPTION
Battery voltage and movement counter is read when fetching data from Ruuvi. Movement counter is built in Ruuvi, and resets to zero when exceeding 254. See Ruuvi documentation for more information: https://ruuvi.com/acceleration-or-movement-measurement/

Resolves #8